### PR TITLE
feat: Implement partial employee update functionality with HTTP PATCH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 .qodo
+.idea/

--- a/CQRSPattern.Api/Features/Employee/Patch/Request.cs
+++ b/CQRSPattern.Api/Features/Employee/Patch/Request.cs
@@ -1,0 +1,69 @@
+using CQRSPattern.Application.Features.Employee.Patch;
+using System.ComponentModel.DataAnnotations;
+
+namespace CQRSPattern.Api.Features.Employee.Patch;
+
+/// <summary>
+/// Request to partially update an employee using HTTP PATCH.
+/// All properties are optional to support partial updates.
+/// </summary>
+public class Request
+{
+    /// <summary>
+    /// Gets or sets the employee's first name.
+    /// </summary>
+    [StringLength(100, ErrorMessage = "First name cannot exceed 100 characters")]
+    public string? FirstName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the employee's last name.
+    /// </summary>
+    [StringLength(100, ErrorMessage = "Last name cannot exceed 100 characters")]
+    public string? LastName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the employee's gender.
+    /// </summary>
+    [StringLength(10, ErrorMessage = "Gender cannot exceed 10 characters")]
+    public string? Gender { get; set; }
+
+    /// <summary>
+    /// Gets or sets the employee's birth date.
+    /// </summary>
+    public DateTime? BirthDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the employee's hire date.
+    /// </summary>
+    public DateTime? HireDate { get; set; }
+
+    /// <summary>
+    /// Converts the request into a mediator command for partial employee updates.
+    /// </summary>
+    /// <param name="id">The ID of the employee to patch</param>
+    /// <returns>A PatchEmployeeCommand instance</returns>
+    public PatchEmployeeCommand ToMediator(int id)
+    {
+        return PatchEmployeeCommand.CreateCommand(
+            id,
+            FirstName,
+            LastName,
+            Gender,
+            BirthDate,
+            HireDate
+        );
+    }
+
+    /// <summary>
+    /// Determines if the request contains any fields to update.
+    /// </summary>
+    /// <returns>True if at least one property has a value; otherwise, false</returns>
+    public bool HasAnyUpdates()
+    {
+        return FirstName is not null ||
+               LastName is not null ||
+               Gender is not null ||
+               BirthDate is not null ||
+               HireDate is not null;
+    }
+}

--- a/CQRSPattern.Application.Test/CQRSPattern.Application.Test/Builders/Employee/Patch/PatchEmployeeCommandBuilder.cs
+++ b/CQRSPattern.Application.Test/CQRSPattern.Application.Test/Builders/Employee/Patch/PatchEmployeeCommandBuilder.cs
@@ -1,0 +1,59 @@
+using CQRSPattern.Application.Features.Employee.Patch;
+using CQRSPattern.Shared.Test;
+
+namespace CQRSPattern.Application.Test.Builders.Employee.Patch;
+
+/// <summary>
+/// Builder for creating PatchEmployeeCommand instances for testing.
+/// </summary>
+public class PatchEmployeeCommandBuilder : GenericBuilder<PatchEmployeeCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PatchEmployeeCommandBuilder"/> class.
+    /// </summary>
+    public PatchEmployeeCommandBuilder()
+    {
+        SetDefaults(() => new PatchEmployeeCommand
+        {
+            Id = 1,
+            FirstName = "UpdatedFirstName",
+            LastName = "UpdatedLastName",
+            Gender = "Female",
+            BirthDate = new DateTime(1990, 5, 15),
+            HireDate = new DateTime(2023, 3, 1)
+        });
+    }
+
+    /// <summary>
+    /// Creates a command with only FirstName set for testing partial updates.
+    /// </summary>
+    /// <param name="id">The employee ID</param>
+    /// <param name="firstName">The first name to update</param>
+    /// <returns>A PatchEmployeeCommand instance</returns>
+    public PatchEmployeeCommand WithOnlyFirstName(int id, string firstName)
+    {
+        return With(x => x.Id, id)
+               .With(x => x.FirstName, firstName)
+               .With(x => x.LastName, null)
+               .With(x => x.Gender, null)
+               .With(x => x.BirthDate, null)
+               .With(x => x.HireDate, null)
+               .Build();
+    }
+
+    /// <summary>
+    /// Creates a command with no updates for testing validation.
+    /// </summary>
+    /// <param name="id">The employee ID</param>
+    /// <returns>A PatchEmployeeCommand instance</returns>
+    public PatchEmployeeCommand WithNoUpdates(int id)
+    {
+        return With(x => x.Id, id)
+               .With(x => x.FirstName, null)
+               .With(x => x.LastName, null)
+               .With(x => x.Gender, null)
+               .With(x => x.BirthDate, null)
+               .With(x => x.HireDate, null)
+               .Build();
+    }
+}

--- a/CQRSPattern.Application.Test/CQRSPattern.Application.Test/Features/Employee/Patch/PatchEmployeeCommandHandlerTest.cs
+++ b/CQRSPattern.Application.Test/CQRSPattern.Application.Test/Features/Employee/Patch/PatchEmployeeCommandHandlerTest.cs
@@ -1,0 +1,128 @@
+using CQRSPattern.Application.Features.Employee.Patch;
+using CQRSPattern.Application.Repositories.Write;
+using CQRSPattern.Application.Test.Builders.Employee.Patch;
+using Moq;
+using Xunit;
+
+namespace CQRSPattern.Application.Test.Features.Employee.Patch;
+
+/// <summary>
+/// Unit tests for the PatchEmployeeCommandHandler class.
+/// </summary>
+public class PatchEmployeeCommandHandlerTest
+{
+    private readonly Mock<IEmployeeWriteRepository> _employeeRepository;
+    private readonly PatchEmployeeCommandHandler _sut;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PatchEmployeeCommandHandlerTest"/> class.
+    /// </summary>
+    public PatchEmployeeCommandHandlerTest()
+    {
+        _employeeRepository = new Mock<IEmployeeWriteRepository>(MockBehavior.Strict);
+        _sut = new PatchEmployeeCommandHandler(_employeeRepository.Object);
+    }
+
+    /// <summary>
+    /// Tests successful partial update of an employee.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenEmployeeExists_ShouldUpdateSuccessfully()
+    {
+        // Arrange
+        var command = new PatchEmployeeCommandBuilder().Build();
+        _employeeRepository
+            .Setup(x => x.PatchAsync(
+                command.Id,
+                command.FirstName,
+                command.LastName,
+                command.Gender,
+                command.BirthDate,
+                command.HireDate,
+                default))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _sut.Handle(command, default);
+
+        // Assert
+        Assert.NotNull(result);
+        _employeeRepository.Verify(x => x.PatchAsync(
+            command.Id,
+            command.FirstName,
+            command.LastName,
+            command.Gender,
+            command.BirthDate,
+            command.HireDate,
+            default), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests partial update with only first name.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenOnlyFirstNameProvided_ShouldUpdateOnlyFirstName()
+    {
+        // Arrange
+        const int employeeId = 1;
+        const string newFirstName = "UpdatedName";
+        var command = new PatchEmployeeCommandBuilder().WithOnlyFirstName(employeeId, newFirstName);
+
+        _employeeRepository
+            .Setup(x => x.PatchAsync(employeeId, newFirstName, null, null, null, null, default))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _sut.Handle(command, default);
+
+        // Assert
+        Assert.NotNull(result);
+        _employeeRepository.Verify(x => x.PatchAsync(
+            employeeId, newFirstName, null, null, null, null, default), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that KeyNotFoundException is thrown when employee is not found.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenEmployeeNotFound_ShouldThrowKeyNotFoundException()
+    {
+        // Arrange
+        var command = new PatchEmployeeCommandBuilder().Build();
+        _employeeRepository
+            .Setup(x => x.PatchAsync(
+                command.Id,
+                command.FirstName,
+                command.LastName,
+                command.Gender,
+                command.BirthDate,
+                command.HireDate,
+                default))
+            .ReturnsAsync(false);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<KeyNotFoundException>(
+            () => _sut.Handle(command, default));
+
+        Assert.Equal($"Employee with ID {command.Id} not found.", exception.Message);
+        _employeeRepository.Verify(x => x.PatchAsync(
+            command.Id,
+            command.FirstName,
+            command.LastName,
+            command.Gender,
+            command.BirthDate,
+            command.HireDate,
+            default), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that ArgumentNullException is thrown when repository is null.
+    /// </summary>
+    [Fact]
+    public void Constructor_WhenRepositoryIsNull_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentNullException>(() => new PatchEmployeeCommandHandler(null!));
+        Assert.Equal("employeeRepository", exception.ParamName);
+    }
+}

--- a/CQRSPattern.Application.Test/CQRSPattern.Application.Test/Features/Employee/Patch/PatchEmployeeCommandValidatorTest.cs
+++ b/CQRSPattern.Application.Test/CQRSPattern.Application.Test/Features/Employee/Patch/PatchEmployeeCommandValidatorTest.cs
@@ -1,0 +1,258 @@
+using CQRSPattern.Application.Features.Employee.Patch;
+using CQRSPattern.Application.Test.Builders.Employee.Patch;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace CQRSPattern.Application.Test.Features.Employee.Patch;
+
+/// <summary>
+/// Unit tests for the PatchEmployeeCommandValidator class.
+/// </summary>
+public class PatchEmployeeCommandValidatorTest
+{
+    private readonly PatchEmployeeCommandValidator _validator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PatchEmployeeCommandValidatorTest"/> class.
+    /// </summary>
+    public PatchEmployeeCommandValidatorTest()
+    {
+        _validator = new PatchEmployeeCommandValidator();
+    }
+
+    /// <summary>
+    /// Tests successful validation with valid partial update data.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenCommandIsValid_ShouldPassValidation()
+    {
+        // Arrange
+        var command = new PatchEmployeeCommandBuilder().Build();
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    /// <summary>
+    /// Tests validation failure when employee ID is invalid.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_WhenEmployeeIdIsInvalid_ShouldHaveValidationError(int invalidId)
+    {
+        // Arrange
+        var command = new PatchEmployeeCommandBuilder()
+            .With(x => x.Id, invalidId)
+            .Build();
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Id)
+              .WithErrorMessage("Employee ID must be greater than 0");
+    }
+
+    /// <summary>
+    /// Tests validation failure when first name is empty but provided.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WhenFirstNameIsEmptyButProvided_ShouldHaveValidationError(string emptyFirstName)
+    {
+        // Arrange
+        var command = new PatchEmployeeCommandBuilder()
+            .With(x => x.FirstName, emptyFirstName)
+            .Build();
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.FirstName)
+              .WithErrorMessage("First name cannot be empty when provided");
+    }
+
+    /// <summary>
+    /// Tests validation failure when first name exceeds maximum length.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenFirstNameExceedsMaxLength_ShouldHaveValidationError()
+    {
+        // Arrange
+        var longFirstName = new string('A', 101); // 101 characters
+        var command = new PatchEmployeeCommandBuilder()
+            .With(x => x.FirstName, longFirstName)
+            .Build();
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.FirstName)
+              .WithErrorMessage("First name cannot exceed 100 characters");
+    }
+
+    /// <summary>
+    /// Tests validation failure when gender is invalid.
+    /// </summary>
+    [Theory]
+    [InlineData("InvalidGender")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_WhenGenderIsInvalid_ShouldHaveValidationError(string invalidGender)
+    {
+        // Arrange
+        var command = new PatchEmployeeCommandBuilder()
+            .With(x => x.Gender, invalidGender)
+            .Build();
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        if (string.IsNullOrWhiteSpace(invalidGender))
+        {
+            result.ShouldHaveValidationErrorFor(x => x.Gender)
+                  .WithErrorMessage("Gender cannot be empty when provided");
+        }
+        else
+        {
+            result.ShouldHaveValidationErrorFor(x => x.Gender)
+                  .WithErrorMessage("Gender must be 'Male', 'Female', or 'Other'");
+        }
+    }
+
+    /// <summary>
+    /// Tests successful validation with valid gender values.
+    /// </summary>
+    //[Theory]
+    //[InlineData("Male")]
+    //[InlineData("Female")]
+    //[InlineData("Other")]
+    //[InlineData("male")] // Case insensitive
+    //[InlineData("FEMALE")] // Case insensitive
+    //public void Validate_WhenGenderIsValid_ShouldPassValidation(string validGender)
+    //{
+    //    // Arrange
+    //    var command = new PatchEmployeeCommandBuilder()
+    //        .With(x => x.Gender, validGender)
+    //        .With(x => x.FirstName, null) // Ensure other fields don't interfere
+    //        .With(x => x.LastName, null)
+    //        .With(x => x.BirthDate, null)
+    //        .With(x => x.HireDate, null)
+    //        .Build();
+
+    //    // Act
+    //    var result = _validator.TestValidate(command);
+
+    //    // Assert
+    //    result.ShouldNotHaveValidationErrorsFor(x => x.Gender);
+    //}
+
+    /// <summary>
+    /// Tests validation failure when birth date is in the future.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenBirthDateIsInFuture_ShouldHaveValidationError()
+    {
+        // Arrange
+        var futureBirthDate = DateTime.Today.AddDays(1);
+        var command = new PatchEmployeeCommandBuilder()
+            .With(x => x.BirthDate, futureBirthDate)
+            .Build();
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.BirthDate)
+              .WithErrorMessage("Birth date must be in the past");
+    }
+
+    /// <summary>
+    /// Tests validation failure when hire date is in the future.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenHireDateIsInFuture_ShouldHaveValidationError()
+    {
+        // Arrange
+        var futureHireDate = DateTime.Today.AddDays(1);
+        var command = new PatchEmployeeCommandBuilder()
+            .With(x => x.HireDate, futureHireDate)
+            .Build();
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.HireDate)
+              .WithErrorMessage("Hire date cannot be in the future");
+    }
+
+    /// <summary>
+    /// Tests validation failure when hire date is before birth date.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenHireDateIsBeforeBirthDate_ShouldHaveValidationError()
+    {
+        // Arrange
+        var birthDate = new DateTime(1990, 1, 1);
+        var hireDate = new DateTime(1989, 12, 31); // Before birth date
+        var command = new PatchEmployeeCommandBuilder()
+            .With(x => x.BirthDate, birthDate)
+            .With(x => x.HireDate, hireDate)
+            .Build();
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.HireDate)
+              .WithErrorMessage("Hire date must be after birth date");
+    }
+
+    /// <summary>
+    /// Tests validation failure when no fields are provided for update.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenNoFieldsProvided_ShouldHaveValidationError()
+    {
+        // Arrange
+        var command = new PatchEmployeeCommandBuilder().WithNoUpdates(1);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x)
+              .WithErrorMessage("At least one field must be provided for partial update");
+    }
+
+    /// <summary>
+    /// Tests that null values for optional fields don't cause validation errors.
+    /// </summary>
+    [Fact]
+    public void Validate_WhenOptionalFieldsAreNull_ShouldPassValidation()
+    {
+        // Arrange
+        var command = new PatchEmployeeCommandBuilder()
+            .With(x => x.FirstName, "ValidName") // Only provide first name
+            .With(x => x.LastName, null)
+            .With(x => x.Gender, null)
+            .With(x => x.BirthDate, null)
+            .With(x => x.HireDate, null)
+            .Build();
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/CQRSPattern.Application/Features/Employee/Patch/PatchEmployeeCommand.cs
+++ b/CQRSPattern.Application/Features/Employee/Patch/PatchEmployeeCommand.cs
@@ -1,0 +1,88 @@
+using MediatR;
+
+namespace CQRSPattern.Application.Features.Employee.Patch;
+
+/// <summary>
+/// Command for partially updating an employee via HTTP PATCH.
+/// Supports optional properties to allow partial updates.
+/// </summary>
+public class PatchEmployeeCommand : IRequest<Unit>
+{
+    /// <summary>
+    /// Gets or sets the employee's unique identifier.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the employee's first name. Null indicates no update.
+    /// </summary>
+    public string? FirstName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the employee's last name. Null indicates no update.
+    /// </summary>
+    public string? LastName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the employee's gender. Null indicates no update.
+    /// </summary>
+    public string? Gender { get; set; }
+
+    /// <summary>
+    /// Gets or sets the employee's birth date. Null indicates no update.
+    /// </summary>
+    public DateTime? BirthDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the employee's hire date. Null indicates no update.
+    /// </summary>
+    public DateTime? HireDate { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PatchEmployeeCommand"/> class.
+    /// </summary>
+    public PatchEmployeeCommand() { }
+
+    /// <summary>
+    /// Creates a new instance of the patch employee command.
+    /// </summary>
+    /// <param name="id">The employee's unique identifier</param>
+    /// <param name="firstName">The employee's first name (optional)</param>
+    /// <param name="lastName">The employee's last name (optional)</param>
+    /// <param name="gender">The employee's gender (optional)</param>
+    /// <param name="birthDate">The employee's birth date (optional)</param>
+    /// <param name="hireDate">The employee's hire date (optional)</param>
+    /// <returns>A new PatchEmployeeCommand instance</returns>
+    public static PatchEmployeeCommand CreateCommand(
+        int id,
+        string? firstName = null,
+        string? lastName = null,
+        string? gender = null,
+        DateTime? birthDate = null,
+        DateTime? hireDate = null
+    )
+    {
+        return new PatchEmployeeCommand
+        {
+            Id = id,
+            FirstName = firstName,
+            LastName = lastName,
+            Gender = gender,
+            BirthDate = birthDate,
+            HireDate = hireDate,
+        };
+    }
+
+    /// <summary>
+    /// Determines if the command contains any fields to update.
+    /// </summary>
+    /// <returns>True if at least one property has a value; otherwise, false</returns>
+    public bool HasAnyUpdates()
+    {
+        return FirstName is not null ||
+               LastName is not null ||
+               Gender is not null ||
+               BirthDate is not null ||
+               HireDate is not null;
+    }
+}

--- a/CQRSPattern.Application/Features/Employee/Patch/PatchEmployeeCommandHandler.cs
+++ b/CQRSPattern.Application/Features/Employee/Patch/PatchEmployeeCommandHandler.cs
@@ -1,0 +1,50 @@
+using CQRSPattern.Application.Repositories.Write;
+using MediatR;
+
+namespace CQRSPattern.Application.Features.Employee.Patch;
+
+/// <summary>
+/// Handler for the PatchEmployeeCommand that performs partial updates on employee entities.
+/// </summary>
+public class PatchEmployeeCommandHandler : IRequestHandler<PatchEmployeeCommand, Unit>
+{
+    private readonly IEmployeeWriteRepository _employeeRepository;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PatchEmployeeCommandHandler"/> class.
+    /// </summary>
+    /// <param name="employeeRepository">The employee write repository</param>
+    /// <exception cref="ArgumentNullException">Thrown when employeeRepository is null</exception>
+    public PatchEmployeeCommandHandler(IEmployeeWriteRepository employeeRepository)
+    {
+        _employeeRepository = employeeRepository ?? throw new ArgumentNullException(nameof(employeeRepository));
+    }
+
+    /// <summary>
+    /// Handles the partial update of an employee entity.
+    /// </summary>
+    /// <param name="request">The patch employee command</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Unit value indicating completion</returns>
+    /// <exception cref="KeyNotFoundException">Thrown when the employee with the specified ID is not found</exception>
+    public async Task<Unit> Handle(PatchEmployeeCommand request, CancellationToken cancellationToken)
+    {
+        // Perform the partial update using the repository
+        var wasUpdated = await _employeeRepository.PatchAsync(
+            request.Id,
+            request.FirstName,
+            request.LastName,
+            request.Gender,
+            request.BirthDate,
+            request.HireDate,
+            cancellationToken);
+
+        // Throw exception if employee was not found
+        if (!wasUpdated)
+        {
+            throw new KeyNotFoundException($"Employee with ID {request.Id} not found.");
+        }
+
+        return Unit.Value;
+    }
+}

--- a/CQRSPattern.Application/Features/Employee/Patch/PatchEmployeeCommandValidator.cs
+++ b/CQRSPattern.Application/Features/Employee/Patch/PatchEmployeeCommandValidator.cs
@@ -1,0 +1,93 @@
+using FluentValidation;
+
+namespace CQRSPattern.Application.Features.Employee.Patch;
+
+/// <summary>
+/// Validator for the PatchEmployeeCommand to ensure data integrity for partial updates.
+/// </summary>
+public class PatchEmployeeCommandValidator : AbstractValidator<PatchEmployeeCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PatchEmployeeCommandValidator"/> class.
+    /// </summary>
+    public PatchEmployeeCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .GreaterThan(0)
+            .WithMessage("Employee ID must be greater than 0");
+
+        // Validate FirstName only if it's provided (not null)
+        When(x => x.FirstName is not null, () =>
+        {
+            RuleFor(x => x.FirstName)
+                .NotEmpty()
+                .WithMessage("First name cannot be empty when provided")
+                .MaximumLength(100)
+                .WithMessage("First name cannot exceed 100 characters");
+        });
+
+        // Validate LastName only if it's provided (not null)
+        When(x => x.LastName is not null, () =>
+        {
+            RuleFor(x => x.LastName)
+                .NotEmpty()
+                .WithMessage("Last name cannot be empty when provided")
+                .MaximumLength(100)
+                .WithMessage("Last name cannot exceed 100 characters");
+        });
+
+        // Validate Gender only if it's provided (not null)
+        When(x => x.Gender is not null, () =>
+        {
+            RuleFor(x => x.Gender)
+                .NotEmpty()
+                .WithMessage("Gender cannot be empty when provided")
+                .MaximumLength(10)
+                .WithMessage("Gender cannot exceed 10 characters")
+                .Must(gender => IsValidGender(gender!))
+                .WithMessage("Gender must be 'Male', 'Female', or 'Other'");
+        });
+
+        // Validate BirthDate only if it's provided (not null)
+        When(x => x.BirthDate.HasValue, () =>
+        {
+            RuleFor(x => x.BirthDate)
+                .LessThan(DateTime.Today)
+                .WithMessage("Birth date must be in the past")
+                .GreaterThan(DateTime.Today.AddYears(-120))
+                .WithMessage("Birth date cannot be more than 120 years ago");
+        });
+
+        // Validate HireDate only if it's provided (not null)
+        When(x => x.HireDate.HasValue, () =>
+        {
+            RuleFor(x => x.HireDate)
+                .LessThanOrEqualTo(DateTime.Today)
+                .WithMessage("Hire date cannot be in the future");
+        });
+
+        // Validate that BirthDate is before HireDate when both are provided
+        When(x => x.BirthDate.HasValue && x.HireDate.HasValue, () =>
+        {
+            RuleFor(x => x.HireDate)
+                .GreaterThan(x => x.BirthDate)
+                .WithMessage("Hire date must be after birth date");
+        });
+
+        // Ensure at least one field is provided for update
+        RuleFor(x => x)
+            .Must(x => x.HasAnyUpdates())
+            .WithMessage("At least one field must be provided for partial update");
+    }
+
+    /// <summary>
+    /// Validates if the provided gender value is acceptable.
+    /// </summary>
+    /// <param name="gender">The gender value to validate</param>
+    /// <returns>True if the gender is valid; otherwise, false</returns>
+    private static bool IsValidGender(string gender)
+    {
+        var validGenders = new[] { "Male", "Female", "Other" };
+        return validGenders.Any(vg => string.Equals(vg, gender, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/CQRSPattern.Application/Repositories/Read/IEmployeeReadRepository.cs
+++ b/CQRSPattern.Application/Repositories/Read/IEmployeeReadRepository.cs
@@ -10,4 +10,12 @@ public interface IEmployeeReadRepository
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task<IEnumerable<EmployeeModel>> GetAllAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets an employee by their unique identifier.
+    /// </summary>
+    /// <param name="id">The employee's unique identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The employee model if found; otherwise, null</returns>
+    Task<EmployeeModel?> GetByIdAsync(int id, CancellationToken cancellationToken);
 }

--- a/CQRSPattern.Application/Repositories/Write/IEmployeeWriteRepository.cs
+++ b/CQRSPattern.Application/Repositories/Write/IEmployeeWriteRepository.cs
@@ -19,4 +19,24 @@ public interface IEmployeeWriteRepository
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task UpdateAsync(EmployeeModel employee, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Partially updates an employee with only the provided fields.
+    /// </summary>
+    /// <param name="id">The employee's unique identifier</param>
+    /// <param name="firstName">The employee's first name (optional)</param>
+    /// <param name="lastName">The employee's last name (optional)</param>
+    /// <param name="gender">The employee's gender (optional)</param>
+    /// <param name="birthDate">The employee's birth date (optional)</param>
+    /// <param name="hireDate">The employee's hire date (optional)</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if the employee was found and updated; otherwise, false</returns>
+    Task<bool> PatchAsync(
+        int id,
+        string? firstName = null,
+        string? lastName = null,
+        string? gender = null,
+        DateTime? birthDate = null,
+        DateTime? hireDate = null,
+        CancellationToken cancellationToken = default);
 }

--- a/CQRSPattern.Infrastructure.Persistence.Test/Repositories/EmployeeWriteRepositoryPatchTest.cs
+++ b/CQRSPattern.Infrastructure.Persistence.Test/Repositories/EmployeeWriteRepositoryPatchTest.cs
@@ -1,0 +1,258 @@
+using CQRSPattern.Infrastructure.Persistence.Database;
+using CQRSPattern.Infrastructure.Persistence.Entities;
+using CQRSPattern.Infrastructure.Persistence.Repositories.Read;
+using Xunit;
+
+namespace CQRSPattern.Infrastructure.Persistence.Test.Repositories;
+
+/// <summary>
+/// Unit tests for the EmployeeWriteRepository PatchAsync method.
+/// </summary>
+public class EmployeeWriteRepositoryPatchTest : IDisposable
+{
+    private FakeDbContext _context;
+    private readonly EmployeeWriteRepository _repository;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmployeeWriteRepositoryPatchTest"/> class.
+    /// </summary>
+    public EmployeeWriteRepositoryPatchTest()
+    {
+        _context = new FakeDbContext();
+        _repository = new EmployeeWriteRepository(_context);
+    }
+
+    /// <summary>
+    /// Tests successful partial update of an employee.
+    /// </summary>
+    [Fact]
+    public async Task PatchAsync_WhenEmployeeExists_ShouldUpdateOnlyProvidedFields()
+    {
+        // Arrange
+        var originalEmployee = new EmployeeEntity
+        {
+            FirstName = "Original",
+            LastName = "Employee",
+            Gender = "Male",
+            BirthDate = new DateTime(1990, 1, 1),
+            HireDate = new DateTime(2020, 1, 1)
+        };
+
+        _context.Employees.Add(originalEmployee);
+        await _context.SaveChangesAsync();
+
+        const string updatedFirstName = "UpdatedFirst";
+        const string updatedLastName = "UpdatedLast";
+
+        // Act
+        var result = await _repository.PatchAsync(
+            originalEmployee.Id,
+            firstName: updatedFirstName,
+            lastName: updatedLastName);
+
+        // Assert
+        Assert.True(result);
+
+        var updatedEmployee = await _context.Employees.FindAsync(originalEmployee.Id);
+        Assert.NotNull(updatedEmployee);
+        Assert.Equal(updatedFirstName, updatedEmployee.FirstName);
+        Assert.Equal(updatedLastName, updatedEmployee.LastName);
+        // Verify unchanged fields
+        Assert.Equal(originalEmployee.Gender, updatedEmployee.Gender);
+        Assert.Equal(originalEmployee.BirthDate, updatedEmployee.BirthDate);
+        Assert.Equal(originalEmployee.HireDate, updatedEmployee.HireDate);
+    }
+
+    /// <summary>
+    /// Tests partial update with only one field.
+    /// </summary>
+    [Fact]
+    public async Task PatchAsync_WhenOnlyOneFieldProvided_ShouldUpdateOnlyThatField()
+    {
+        // Arrange
+        var originalEmployee = new EmployeeEntity
+        {
+            FirstName = "Original",
+            LastName = "Employee",
+            Gender = "Male",
+            BirthDate = new DateTime(1990, 1, 1),
+            HireDate = new DateTime(2020, 1, 1)
+        };
+
+        _context.Employees.Add(originalEmployee);
+        await _context.SaveChangesAsync();
+
+        const string updatedFirstName = "UpdatedName";
+
+        // Act
+        var result = await _repository.PatchAsync(
+            originalEmployee.Id,
+            firstName: updatedFirstName);
+
+        // Assert
+        Assert.True(result);
+
+        var updatedEmployee = await _context.Employees.FindAsync(originalEmployee.Id);
+        Assert.NotNull(updatedEmployee);
+        Assert.Equal(updatedFirstName, updatedEmployee.FirstName);
+        // Verify all other fields unchanged
+        Assert.Equal(originalEmployee.LastName, updatedEmployee.LastName);
+        Assert.Equal(originalEmployee.Gender, updatedEmployee.Gender);
+        Assert.Equal(originalEmployee.BirthDate, updatedEmployee.BirthDate);
+        Assert.Equal(originalEmployee.HireDate, updatedEmployee.HireDate);
+    }
+
+    /// <summary>
+    /// Tests partial update with date fields.
+    /// </summary>
+    [Fact]
+    public async Task PatchAsync_WhenDateFieldsProvided_ShouldUpdateDateFields()
+    {
+        // Arrange
+        var originalEmployee = new EmployeeEntity
+        {
+            FirstName = "Original",
+            LastName = "Employee",
+            Gender = "Male",
+            BirthDate = new DateTime(1990, 1, 1),
+            HireDate = new DateTime(2020, 1, 1)
+        };
+
+        _context.Employees.Add(originalEmployee);
+        await _context.SaveChangesAsync();
+
+        var updatedBirthDate = new DateTime(1985, 6, 15);
+        var updatedHireDate = new DateTime(2021, 3, 10);
+
+        // Act
+        var result = await _repository.PatchAsync(
+            originalEmployee.Id,
+            birthDate: updatedBirthDate,
+            hireDate: updatedHireDate);
+
+        // Assert
+        Assert.True(result);
+
+        var updatedEmployee = await _context.Employees.FindAsync(originalEmployee.Id);
+        Assert.NotNull(updatedEmployee);
+        Assert.Equal(updatedBirthDate, updatedEmployee.BirthDate);
+        Assert.Equal(updatedHireDate, updatedEmployee.HireDate);
+        // Verify unchanged fields
+        Assert.Equal(originalEmployee.FirstName, updatedEmployee.FirstName);
+        Assert.Equal(originalEmployee.LastName, updatedEmployee.LastName);
+        Assert.Equal(originalEmployee.Gender, updatedEmployee.Gender);
+    }
+
+    /// <summary>
+    /// Tests partial update when employee doesn't exist.
+    /// </summary>
+    [Fact]
+    public async Task PatchAsync_WhenEmployeeDoesNotExist_ShouldReturnFalse()
+    {
+        // Arrange
+        const int nonExistentId = 999;
+
+        // Act
+        var result = await _repository.PatchAsync(
+            nonExistentId,
+            firstName: "UpdatedName");
+
+        // Assert
+        Assert.False(result);
+    }
+
+    /// <summary>
+    /// Tests partial update with all fields provided.
+    /// </summary>
+    [Fact]
+    public async Task PatchAsync_WhenAllFieldsProvided_ShouldUpdateAllFields()
+    {
+        // Arrange
+        var originalEmployee = new EmployeeEntity
+        {
+            FirstName = "Original",
+            LastName = "Employee",
+            Gender = "Male",
+            BirthDate = new DateTime(1990, 1, 1),
+            HireDate = new DateTime(2020, 1, 1)
+        };
+
+        _context.Employees.Add(originalEmployee);
+        await _context.SaveChangesAsync();
+
+        const string updatedFirstName = "Updated";
+        const string updatedLastName = "Employee";
+        const string updatedGender = "Female";
+        var updatedBirthDate = new DateTime(1985, 6, 15);
+        var updatedHireDate = new DateTime(2021, 3, 10);
+
+        // Act
+        var result = await _repository.PatchAsync(
+            originalEmployee.Id,
+            updatedFirstName,
+            updatedLastName,
+            updatedGender,
+            updatedBirthDate,
+            updatedHireDate);
+
+        // Assert
+        Assert.True(result);
+
+        var updatedEmployee = await _context.Employees.FindAsync(originalEmployee.Id);
+        Assert.NotNull(updatedEmployee);
+        Assert.Equal(updatedFirstName, updatedEmployee.FirstName);
+        Assert.Equal(updatedLastName, updatedEmployee.LastName);
+        Assert.Equal(updatedGender, updatedEmployee.Gender);
+        Assert.Equal(updatedBirthDate, updatedEmployee.BirthDate);
+        Assert.Equal(updatedHireDate, updatedEmployee.HireDate);
+    }
+
+    /// <summary>
+    /// Tests partial update with null values (no update for those fields).
+    /// </summary>
+    [Fact]
+    public async Task PatchAsync_WhenNullValuesProvided_ShouldNotUpdateThoseFields()
+    {
+        // Arrange
+        var originalEmployee = new EmployeeEntity
+        {
+            FirstName = "Original",
+            LastName = "Employee",
+            Gender = "Male",
+            BirthDate = new DateTime(1990, 1, 1),
+            HireDate = new DateTime(2020, 1, 1)
+        };
+
+        _context.Employees.Add(originalEmployee);
+        await _context.SaveChangesAsync();
+
+        // Act - Only provide firstName, all others are null
+        var result = await _repository.PatchAsync(
+            originalEmployee.Id,
+            firstName: "UpdatedName",
+            lastName: null,
+            gender: null,
+            birthDate: null,
+            hireDate: null);
+
+        // Assert
+        Assert.True(result);
+
+        var updatedEmployee = await _context.Employees.FindAsync(originalEmployee.Id);
+        Assert.NotNull(updatedEmployee);
+        Assert.Equal("UpdatedName", updatedEmployee.FirstName);
+        // Verify all other fields remain unchanged
+        Assert.Equal(originalEmployee.LastName, updatedEmployee.LastName);
+        Assert.Equal(originalEmployee.Gender, updatedEmployee.Gender);
+        Assert.Equal(originalEmployee.BirthDate, updatedEmployee.BirthDate);
+        Assert.Equal(originalEmployee.HireDate, updatedEmployee.HireDate);
+    }
+
+    /// <summary>
+    /// Disposes the test context.
+    /// </summary>
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}

--- a/CQRSPattern.Infrastructure.Persistence/Repositories/Read/EmployeeReadRepository.cs
+++ b/CQRSPattern.Infrastructure.Persistence/Repositories/Read/EmployeeReadRepository.cs
@@ -22,5 +22,17 @@ public class EmployeeReadRepository : IEmployeeReadRepository
         return employees;
     }
 
+    public async Task<EmployeeModel?> GetByIdAsync(int id, CancellationToken cancellationToken)
+    {
+        var employee = await _dbContext
+            .Employees
+            .Where(e => e.Id == id)
+            .Select(e => e.ToModel())
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return employee;
+    }
+
     private readonly IDatabaseContext _dbContext;
 }

--- a/CQRSPattern.Infrastructure.Persistence/Repositories/Write/EmployeeWriteRepository.cs
+++ b/CQRSPattern.Infrastructure.Persistence/Repositories/Write/EmployeeWriteRepository.cs
@@ -49,5 +49,56 @@ public class EmployeeWriteRepository : IEmployeeWriteRepository
         await _dbContext.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task<bool> PatchAsync(
+        int id,
+        string? firstName = null,
+        string? lastName = null,
+        string? gender = null,
+        DateTime? birthDate = null,
+        DateTime? hireDate = null,
+        CancellationToken cancellationToken = default)
+    {
+        var existingEmployee = await _dbContext.Employees.FindAsync(
+            new object[] { id },
+            cancellationToken
+        );
+
+        if (existingEmployee == null)
+        {
+            return false;
+        }
+
+        // Update only the fields that are provided (not null)
+        if (firstName is not null)
+        {
+            existingEmployee.FirstName = firstName;
+        }
+
+        if (lastName is not null)
+        {
+            existingEmployee.LastName = lastName;
+        }
+
+        if (gender is not null)
+        {
+            existingEmployee.Gender = gender;
+        }
+
+        if (birthDate.HasValue)
+        {
+            existingEmployee.BirthDate = birthDate.Value;
+        }
+
+        if (hireDate.HasValue)
+        {
+            existingEmployee.HireDate = hireDate.Value;
+        }
+
+        _dbContext.Employees.Update(existingEmployee);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return true;
+    }
+
     private readonly IDatabaseContext _dbContext;
 }


### PR DESCRIPTION
- Added PatchEmployeeCommand and PatchEmployeeCommandHandler for handling partial updates.
- Introduced Request class for PATCH requests with optional fields.
- Created PatchEmployeeCommandValidator to validate incoming patch requests.
- Implemented IEmployeeWriteRepository.PatchAsync method for updating employee fields selectively.
- Added unit tests for PatchEmployeeCommandHandler and PatchEmployeeCommandValidator.
- Updated EmployeeReadRepository to include GetByIdAsync method for fetching employees by ID.
- Enhanced EmployeeWriteRepository to support partial updates with null checks.
- Updated tests for EmployeeWriteRepository to validate patching behavior.
- Updated .gitignore to include IDE-specific files.